### PR TITLE
Configure `beyondViewportPageCount` to let Coil preload article images

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/terrakok/wikwok/ui/WikipediaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/terrakok/wikwok/ui/WikipediaScreen.kt
@@ -143,6 +143,7 @@ fun WikipediaScreen(
                 // TikTok-like fullscreen pager using VerticalPager
                 VerticalPager(
                     state = pagerState,
+                    beyondViewportPageCount = 1,
                     modifier = Modifier.fillMaxSize()
                 ) { pageIndex ->
                     if (pageIndex < uiState.articles.size) {


### PR DESCRIPTION
Looks more smooth without black placeholders transforming into pictures on the go